### PR TITLE
Feat/frontend advance payload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
+#Never store secrets in frontend env variables. 
+#In Vite, anything starting with VITE_ gets bundled and becomes visible in the browser.
+
 VITE_API_BASE_URL=http://localhost:5174/api/v1
 VITE_APP_NAME=Olejra

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -1,0 +1,9 @@
+import { api } from "../api/axios";
+
+export function advanceTask(taskId, from, to) {
+  return api.post("/tasks/advance", {
+    taskId,
+    from,
+    to,
+  });
+}

--- a/src/utils/status.js
+++ b/src/utils/status.js
@@ -1,0 +1,10 @@
+// STATUS_FLOW defines the strict order of task statuses.
+// Used for column order and to validate allowed forward transitions.
+export const STATUS_FLOW = ["BACKLOG", "TODO", "IN_PROGRESS", "DONE"];
+
+export function canTransition(from, to) {
+  const fromIndex = STATUS_FLOW.indexOf(from);
+  const toIndex = STATUS_FLOW.indexOf(to);
+
+  return toIndex - fromIndex === 1;
+}


### PR DESCRIPTION
Updated frontend to use the new /tasks/advance payload API.
Refactored BoardPage to use STATUS_FLOW and local transition guards.
Added loading lock to prevent duplicate requests.
Unified axios client usage across components.
Fixed 404 errors by aligning frontend routes with backend.