### PR TITLE
Feat/front task details

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from "react-router-dom";
 import Login from "./components/pages/LoginPage.jsx";
 import Board from "./components/pages/BoardPage.jsx";
 import AuthGate from "./components/auth/AuthGate.jsx";
+import TaskDetailsPage from "./components/pages/TaskDetailsPage.jsx";
 
 import "./App.css";
 
@@ -14,6 +15,14 @@ function App() {
         element={
           <AuthGate>
             <Board />
+          </AuthGate>
+        }
+      />
+      <Route
+        path="/tasks/:id"
+        element={
+          <AuthGate>
+            <TaskDetailsPage />
           </AuthGate>
         }
       />

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -7,3 +7,11 @@ export function advanceTask(taskId, from, to) {
     to,
   });
 }
+
+export function getTask(taskId) {
+  return api.get(`/tasks/${taskId}`);
+}
+
+export function updateTask(taskId, data) {
+  return api.patch(`/tasks/${taskId}`, data);
+}

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -1,5 +1,6 @@
 import { api } from "../api/axios";
 
+// Move task forward using backend transition API.
 export function advanceTask(taskId, from, to) {
   return api.post("/tasks/advance", {
     taskId,
@@ -8,10 +9,14 @@ export function advanceTask(taskId, from, to) {
   });
 }
 
+// Get full task details by id.
 export function getTask(taskId) {
+  // Returns title, description, status, timestamps...
   return api.get(`/tasks/${taskId}`);
 }
 
+// Update task title and/or description.
 export function updateTask(taskId, data) {
+  // data: { title?, description? }
   return api.patch(`/tasks/${taskId}`, data);
 }

--- a/src/components/pages/BoardPage.css
+++ b/src/components/pages/BoardPage.css
@@ -45,6 +45,11 @@
   border-color: #d8dee9;
 }
 
+.column:hover {
+  background-color: #f5f7fb; /* slightly darker than board background so columns stand out */
+  border-color: #cbd5e1;
+}
+
 .task {
   display: flex;
   align-items: center;
@@ -56,11 +61,17 @@
   margin-bottom: 10px;
   font-size: 14px;
   line-height: 1.3;
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease,
+              box-shadow 0.2s ease,
+              background-color 0.2s ease,
+              transform 0.08s ease;
 }
 
 .task:hover {
   border-color: #cbd5e1;
+  background-color: rgba(15, 23, 42, 0.02); 
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08); /* lift card on hover */
+  transform: translateY(-1px);
 }
 
 .task__title {

--- a/src/components/pages/BoardPage.jsx
+++ b/src/components/pages/BoardPage.jsx
@@ -83,9 +83,9 @@ export default function BoardPage() {
   return (
     <div className="board">
       <div className="board__header">
-        <h1 className="board__title">Моя дошка задач</h1>
+        <h1 className="board__title">Olejra - choose the future !</h1>
         <button className="logout-btn" onClick={handleLogout} aria-label="Вийти з акаунту" title="Вийти">
-          Вийти
+          Exit
         </button>
       </div>
 

--- a/src/components/pages/BoardPage.jsx
+++ b/src/components/pages/BoardPage.jsx
@@ -96,7 +96,9 @@ export default function BoardPage() {
 
             {columns[status].map((task) => (
               <div key={task.id} className="task">
-                <span className="task__title">{task.title}</span>
+                <span className="task__title" onClick={() => navigate(`/tasks/${task.id}`)} tabIndex={0}>
+                  {task.title}
+                </span>
                 {task.status !== "DONE" && (
                   <button onClick={() => handleAdvance(task)} disabled={loading[task.id]} className="task__button" title="Move to next column">
                     →

--- a/src/components/pages/LoginPage.jsx
+++ b/src/components/pages/LoginPage.jsx
@@ -20,7 +20,7 @@ export default function LoginPage() {
     const emailTrim = email.trim();
     const pass = password;
     if (!emailTrim || !pass) {
-      setError("Заповніть email і пароль");
+      setError("Please fill email and password");
       return;
     }
 
@@ -34,25 +34,25 @@ export default function LoginPage() {
         const { status, data } = err.response;
         switch (status) {
           case 401:
-            setError("Невірна пошта або пароль");
+            setError("Invalid email or password");
             break;
           case 429:
-            setError("Забагато спроб. Спробуйте пізніше.");
+            setError("Too many attempts. Please try again later.");
             break;
           case 422:
-            setError(data?.error || "Некоректні дані форми");
+            setError(data?.error || "Invalid form data");
             break;
           default:
             if (status >= 500) {
-              setError("Помилка сервера. Спробуйте ще раз пізніше.");
+              setError("Server error. Please try again later.");
             } else {
-              setError(data?.error || `Помилка сервера: ${status}`);
+              setError(data?.error || `Server Error: ${status}`);
             }
         }
       } else if (err?.request) {
-        setError("Не вдалося під’єднатися до бекенда");
+        setError("Failed to connect to the backend");
       } else {
-        setError(`Помилка: ${err?.message || "невідома помилка"}`);
+        setError(`Error: ${err?.message || "unknown error"}`);
       }
     } finally {
       setSubmitting(false);
@@ -61,14 +61,14 @@ export default function LoginPage() {
 
   return (
     <form onSubmit={handleSubmit} noValidate>
-      <h1>Вхід</h1>
+      <h1>Access your workspace</h1>
 
-      <input type="email" inputMode="email" autoComplete="email" placeholder="логін@приклад.com" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      <input type="email" inputMode="email" autoComplete="email" placeholder="your@email.com" value={email} onChange={(e) => setEmail(e.target.value)} required />
 
       <input type="password" autoComplete="current-password" placeholder="••••••••" value={password} onChange={(e) => setPassword(e.target.value)} required minLength={6} />
 
       <button type="submit" disabled={isSubmitting} aria-busy={isSubmitting} aria-disabled={isSubmitting}>
-        {isSubmitting ? "Увійти…" : "Увійти"}
+        {isSubmitting ? "Log in..." : "Log in"}
       </button>
 
       {error && (

--- a/src/components/pages/TaskDetailsPage.css
+++ b/src/components/pages/TaskDetailsPage.css
@@ -1,0 +1,144 @@
+/* Task details layout */
+.task-details {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 32px 20px 60px;
+  min-height: 100vh;
+  box-sizing: border-box;
+  background: var(--bg);
+  color: var(--text);
+}
+
+/* Back button */
+.task-details > button[type="button"] {
+  border: none;
+  background: #000;
+  color: #fff;
+  font-size: 14px;
+  padding: 8px 14px;
+  border-radius: var(--radius);
+  cursor: pointer;
+  margin-bottom: 20px;
+  transition: background 0.15s ease;
+}
+
+.task-details > button[type="button"]:hover {
+  background: var(--accent-hover);
+}
+
+/* Title */
+.task-details h1 {
+  font-size: 24px;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+/* Main content: meta + form */
+.task-details__meta,
+.task-details__form {
+  margin-top: 0;
+}
+
+/* Two-column layout */
+.task-details__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(320px, 1.6fr);
+  gap: 32px;
+  align-items: flex-start;
+}
+
+/* Meta block */
+.task-details__meta p {
+  margin: 4px 0;
+  font-size: 14px;
+}
+
+.task-details__meta strong {
+  font-weight: 600;
+}
+
+/* Form card */
+.task-details__form {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px 20px 24px;
+  box-shadow: var(--shadow-soft);
+}
+
+/* Fields */
+.task-details .field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.task-details .field label {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.task-details .field input,
+.task-details .field textarea {
+  font-family: inherit;
+  font-size: 14px;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text);
+  outline: none;
+}
+
+.task-details .field input:focus,
+.task-details .field textarea:focus {
+  border-color: var(--accent-strong);
+}
+
+/* Submit button */
+.task-details__form button[type="submit"] {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 18px;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  background: #000;
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.task-details__form button[type="submit"]:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.task-details__form button[type="submit"]:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+/* Error */
+.task-details__error {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #c53030;
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .task-details {
+    padding: 24px 16px 40px;
+  }
+
+  .task-details__content {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+
+  .task-details__form {
+    padding: 20px 16px;
+  }
+}

--- a/src/components/pages/TaskDetailsPage.jsx
+++ b/src/components/pages/TaskDetailsPage.jsx
@@ -1,0 +1,1 @@
+import { useEffect } from "react";

--- a/src/components/pages/TaskDetailsPage.jsx
+++ b/src/components/pages/TaskDetailsPage.jsx
@@ -1,1 +1,160 @@
-import { useEffect } from "react";
+// olejra-frontend/src/components/pages/TaskDetailsPage.jsx
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { getTask, updateTask } from "../../api/tasks";
+import { STATUS_FLOW } from "../../utils/status";
+import "./TaskDetailsPage.css";
+
+// Human-readable labels for statuses; should match BoardPage.
+const statusNames = {
+  BACKLOG: "Backlog",
+  TODO: "To-do",
+  IN_PROGRESS: "In-progress",
+  DONE: "Done",
+};
+
+export default function TaskDetailsPage() {
+  const { id } = useParams(); // /tasks/:id
+  const navigate = useNavigate();
+
+  const [task, setTask] = useState(null);
+  const [form, setForm] = useState({ title: "", description: "" });
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Load task details
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchTask() {
+      try {
+        setLoading(true);
+        const res = await getTask(id);
+        if (cancelled) return;
+
+        setTask(res.data);
+        setForm({
+          title: res.data.title ?? "",
+          description: res.data.description ?? "",
+        });
+        setError(null);
+      } catch (err) {
+        if (cancelled) return;
+        console.error("Failed to load task details", err);
+        setError("Failed to load task.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    fetchTask();
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  function handleChange(e) {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  }
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    if (!task) return;
+
+    // Nothing changed → skip request
+    if (form.title === task.title && (form.description ?? "") === (task.description ?? "")) {
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const res = await updateTask(task.id, {
+        title: form.title,
+        description: form.description,
+      });
+      setTask(res.data);
+      setError(null);
+    } catch (err) {
+      console.error("Failed to update task", err);
+      setError("Failed to save changes.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleBack() {
+    navigate("/board");
+  }
+
+  if (loading) {
+    return (
+      <div className="task-details">
+        <button type="button" onClick={handleBack}>
+          ← Back to board
+        </button>
+        <p>Loading task…</p>
+      </div>
+    );
+  }
+
+  if (error || !task) {
+    return (
+      <div className="task-details">
+        <button type="button" onClick={handleBack}>
+          ← Back to board
+        </button>
+        <p>{error || "Task not found."}</p>
+      </div>
+    );
+  }
+
+  const statusLabel = statusNames[task.status] ?? task.status;
+  const statusIndex = STATUS_FLOW.indexOf(task.status);
+  const statusPosition = statusIndex >= 0 ? `${statusIndex + 1} / ${STATUS_FLOW.length}` : "";
+
+  return (
+    <div className="task-details">
+      <button type="button" onClick={handleBack}>
+        ← Back to board
+      </button>
+
+      <h1>Task details</h1>
+      <div className="task-details__content">
+        <div className="task-details__meta">
+          <p>
+            <strong>ID:</strong> {task.id}
+          </p>
+          <p>
+            <strong>Status:</strong> {statusLabel} {statusPosition && <span>({statusPosition})</span>}
+          </p>
+          <p>
+            <strong>Created at:</strong> {new Date(task.createdAt).toLocaleString()}
+          </p>
+          <p>
+            <strong>Updated at:</strong> {new Date(task.updatedAt).toLocaleString()}
+          </p>
+        </div>
+
+        <form className="task-details__form" onSubmit={handleSubmit}>
+          <div className="field">
+            <label htmlFor="title">Title</label>
+            <input id="title" name="title" type="text" value={form.title} onChange={handleChange} maxLength={255} required />
+          </div>
+
+          <div className="field">
+            <label htmlFor="description">Description</label>
+            <textarea id="description" name="description" value={form.description} onChange={handleChange} rows={4} maxLength={2000} placeholder="Describe the task..." />
+          </div>
+
+          <button type="submit" disabled={saving}>
+            {saving ? "Saving…" : "Save changes"}
+          </button>
+        </form>
+
+        {error && <p className="task-details__error">{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,21 @@
 /* Global styles */
 :root {
-  --bg: #f6f7fb;
-  --text: #1f2937;         /* dark gray for text */
-  --muted: #6b7280;        /* gray for hints */
-  --border: #e5e7eb;       /* light border */
-  --card: #ffffff;         /* white cards */
-  --accent: #111827;       /* black-ish for buttons */
+  --bg:       #f3f4f6;   /* slightly darker than white background */
+  --card:     #ffffff;   /* pure white card */
+  --card-hover: #f9fafb; /* subtle contrast on hover */
+
+  --border:   #d1d5db;   /* visible but soft border */
+  --border-hover: #cbd5e1; /* darker border on hover */
+
+  --text:     #111827;   /* deep graphite text color */
+  --text-light: #4b5563; /* for descriptions and secondary text */
+
+  --muted:    #6b7280;   /* muted gray for labels or hints */
+
+  --accent: #111111;        /* rich deep black */
+  --accent-hover: #616161;  /* smooth dark gray hover */
+
+  --error:    #dc2626;   /* clean red for error messages */
 }
 
 html, body, #root {


### PR DESCRIPTION
- Add TaskDetails route and page for /tasks/:id
- Fetch single task by id and prefill title and description fields
- Implement edit form with client-side validation
- Wire Save button to PATCH /api/tasks/:id
- Add "Back to board" navigation from the details page
- Handle loading, success and error states for task update