### PR TITLE
refactor: unify status helpers across BoardPage and TaskDetailsPage

### DIFF
--- a/src/api/axios.jsx
+++ b/src/api/axios.jsx
@@ -6,7 +6,6 @@ export const api = axios.create({
   baseURL: API_BASE_URL,
   withCredentials: true,
   headers: { "Content-Type": "application/json" },
-  validateStatus: () => true,
 });
 
 let interceptorAttached = false;

--- a/src/api/tasks.js
+++ b/src/api/tasks.js
@@ -15,8 +15,8 @@ export function getTask(taskId) {
   return api.get(`/tasks/${taskId}`);
 }
 
-// Update task title and/or description.
+// Update task fields.
+// data can include: { title?, description?, status? }
 export function updateTask(taskId, data) {
-  // data: { title?, description? }
   return api.patch(`/tasks/${taskId}`, data);
 }

--- a/src/components/auth/AuthGate.jsx
+++ b/src/components/auth/AuthGate.jsx
@@ -9,20 +9,24 @@ export default function AuthGate({ children }) {
 
   useEffect(() => {
     let cancelled = false;
+
+    // Check current user session on mount.
     (async () => {
       try {
-        await api.get("/auth/me");
+        await api.get("/auth/me"); // throws on 401 now
         if (!cancelled) {
           setAllowed(true);
           setLoading(false);
         }
-      } catch (_) {
+      } catch (error) {
         if (!cancelled) {
+          console.error("AuthGate: /auth/me failed", error); // simple debug log
           setAllowed(false);
           setLoading(false);
         }
       }
     })();
+
     return () => {
       cancelled = true;
     };

--- a/src/components/pages/TaskDetailsPage.jsx
+++ b/src/components/pages/TaskDetailsPage.jsx
@@ -2,16 +2,9 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { getTask, updateTask } from "../../api/tasks";
-import { STATUS_FLOW } from "../../utils/status";
+import { STATUSES, getStatusLabel, getStatusPosition } from "../../utils/status";
 import "./TaskDetailsPage.css";
 
-// Human-readable labels for statuses; should match BoardPage.
-const statusNames = {
-  BACKLOG: "Backlog",
-  TODO: "To-do",
-  IN_PROGRESS: "In-progress",
-  DONE: "Done",
-};
 
 export default function TaskDetailsPage() {
   const { id } = useParams(); // /tasks/:id
@@ -40,7 +33,7 @@ export default function TaskDetailsPage() {
         setForm({
           title: res.data.title ?? "",
           description: res.data.description ?? "",
-          status: res.data.status ?? STATUS_FLOW[0],
+          status: res.data.status ?? STATUSES[0],
         });
         setError(null);
       } catch (err) {
@@ -73,7 +66,7 @@ export default function TaskDetailsPage() {
     setForm({
       title: task.title ?? "",
       description: task.description ?? "",
-      status: task.status ?? STATUS_FLOW[0],
+      status: task.status ?? STATUSES[0],
     });
     setError(null);
     setIsEditing(true);
@@ -85,7 +78,7 @@ export default function TaskDetailsPage() {
       setForm({
         title: task.title ?? "",
         description: task.description ?? "",
-        status: task.status ?? STATUS_FLOW[0],
+        status: task.status ?? STATUSES[0],
       });
     }
     setError(null);
@@ -157,9 +150,9 @@ export default function TaskDetailsPage() {
     );
   }
 
-  const statusLabel = statusNames[task.status] ?? task.status;
-  const statusIndex = STATUS_FLOW.indexOf(task.status);
-  const statusPosition = statusIndex >= 0 ? `${statusIndex + 1} / ${STATUS_FLOW.length}` : "";
+  const statusLabel = getStatusLabel(task.status);
+  const statusIndex = getStatusPosition(task.status);
+  const statusPosition = statusIndex >= 0 ? `${statusIndex + 1} / ${STATUSES.length}` : "";
 
   return (
     <div className="task-details">
@@ -216,9 +209,9 @@ export default function TaskDetailsPage() {
               <div className="field">
                 <label htmlFor="status">Status</label>
                 <select id="status" name="status" value={form.status} onChange={handleChange}>
-                  {STATUS_FLOW.map((status) => (
+                  {STATUSES.map((status) => (
                     <option key={status} value={status}>
-                      {statusNames[status] ?? status}
+                      {getStatusLabel(status)}
                     </option>
                   ))}
                 </select>

--- a/src/utils/status.js
+++ b/src/utils/status.js
@@ -1,10 +1,37 @@
-// STATUS_FLOW defines the strict order of task statuses.
-// Used for column order and to validate allowed forward transitions.
-export const STATUS_FLOW = ["BACKLOG", "TODO", "IN_PROGRESS", "DONE"];
+// src/utils/status.js
 
-export function canTransition(from, to) {
-  const fromIndex = STATUS_FLOW.indexOf(from);
-  const toIndex = STATUS_FLOW.indexOf(to);
+// All statuses in forward order for board and forms.
+export const STATUSES = ["BACKLOG", "TODO", "IN_PROGRESS", "DONE"];
 
-  return toIndex - fromIndex === 1;
+// Human-readable labels for UI.
+export const STATUS_LABELS = {
+  BACKLOG: "Backlog",
+  TODO: "To-do",
+  IN_PROGRESS: "In-progress",
+  DONE: "Done",
+};
+
+// Get label or fallback to raw status.
+export function getStatusLabel(status) {
+  return STATUS_LABELS[status] ?? status;
+}
+
+// Get position index for sorting or ordering in UI.
+export function getStatusPosition(status) {
+  const index = STATUSES.indexOf(status);
+  // Return -1 when status is not found so callers can detect invalid statuses.
+  return index;
+}
+
+// Check if we can move exactly one step forward in the status flow.
+export function canTransition(fromStatus, toStatus) {
+  if (!fromStatus || !toStatus) return false;
+
+  const fromIndex = STATUSES.indexOf(fromStatus);
+  const toIndex = STATUSES.indexOf(toStatus);
+
+  if (fromIndex === -1 || toIndex === -1) return false;
+
+  // Allow only moving to the immediate next status.
+  return toIndex === fromIndex + 1;
 }


### PR DESCRIPTION
- Use shared status helpers from utils/status on BoardPage and TaskDetailsPage
- Fix local transition checks using canTransition
- Clean up status label/position logic