### PR TITLE
feat(frontend): extract Task board row into reusable component

### DIFF
--- a/src/components/board/Task.jsx
+++ b/src/components/board/Task.jsx
@@ -1,0 +1,24 @@
+// Presentational component for a single task row on the board.
+export function Task({ task, isLoading, onOpenDetails, onAdvance }) {
+  const isDone = task.status === "DONE";
+
+  return (
+    <div className="task">
+      {/* Click on title opens Task Details page */}
+      <span
+        className="task__title"
+        onClick={() => onOpenDetails(task.id)}
+        tabIndex={0} // Allow keyboard focus for better accessibility
+      >
+        {task.title}
+      </span>
+
+      {/* Show advance button only if task is not in DONE status */}
+      {!isDone && (
+        <button onClick={() => onAdvance(task)} disabled={isLoading} className="task__button" title="Move to next column">
+          →
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/pages/BoardPage/BoardPage.jsx
+++ b/src/pages/BoardPage/BoardPage.jsx
@@ -6,6 +6,7 @@ import { advanceTask } from "../../api/tasks";
 import { STATUSES, getStatusLabel, canTransition } from "../../utils/status";
 import { Header } from "../../components/layout/Header/Header";
 import { Column } from "../../components/Board/Column";
+import { Task } from "../../components/Board/Task";
 
 import "./BoardPage.css";
 
@@ -114,16 +115,13 @@ export default function BoardPage() {
         {STATUSES.map((status) => (
           <Column key={status} title={getStatusLabel(status)} hasTasks={columns[status].length > 0}>
             {columns[status].map((task) => (
-              <div key={task.id} className="task">
-                <span className="task__title" onClick={() => navigate(`/tasks/${task.id}`)} tabIndex={0}>
-                  {task.title}
-                </span>
-                {task.status !== "DONE" && (
-                  <button onClick={() => handleAdvance(task)} disabled={loading[task.id]} className="task__button" title="Move to next column">
-                    →
-                  </button>
-                )}
-              </div>
+              <Task
+                key={task.id}
+                task={task}
+                isLoading={!!loading[task.id]} // Pass loading state for this task
+                onOpenDetails={(taskId) => navigate(`/tasks/${taskId}`)}
+                onAdvance={handleAdvance}
+              />
             ))}
           </Column>
         ))}

--- a/src/pages/BoardPage/BoardPage.jsx
+++ b/src/pages/BoardPage/BoardPage.jsx
@@ -1,4 +1,3 @@
-// olejra-frontend/src/components/pages/BoardPage.jsx
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { api } from "../../api/axios";


### PR DESCRIPTION
Extracted the presentational Task component into src/components/Board/Task.jsx, making task rows reusable across the board. Updated BoardPage.jsx to use the new component and removed the inline JSX version to keep page logic cleaner. Styling remains unchanged as all existing CSS classes were preserved. Navigation to task details and advancing tasks now flow through explicit callbacks passed as props. This refactor improves separation of concerns and prepares the board for further UI decomposition.