### PR TITLE
Add environment label and GitHub link to footer

### DIFF
--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -1,0 +1,38 @@
+.olejra-footer {
+  width: 100%;
+  padding: 10px 24px;
+  background: #050816;
+  color: #9ca3af;
+  border-top: 1px solid #111827;
+  font-size: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+}
+
+.olejra-footer__left {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.olejra-footer__separator {
+  opacity: 0.6;
+}
+
+.olejra-footer__right {
+  display: flex;
+  align-items: center;
+}
+
+.olejra-footer__link {
+  text-decoration: none;
+  color: inherit;
+  opacity: 0.85;
+}
+
+.olejra-footer__link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,0 +1,24 @@
+import "./Footer.css";
+
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  // Vite exposes current mode here
+  const envMode = import.meta.env.MODE; // "development" | "production"
+
+  return (
+    <footer className="olejra-footer">
+      <div className="olejra-footer__left">
+        <span>© {year} Olejra</span>
+        <span className="olejra-footer__separator">•</span>
+        <span>ENV: {envMode}</span>
+      </div>
+
+      <div className="olejra-footer__right">
+        <a href="https://github.com/Filiczini/" target="_blank" rel="noreferrer" className="olejra-footer__link">
+          GitHub ↗
+        </a>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/layout/Header/Header.css
+++ b/src/components/layout/Header/Header.css
@@ -96,6 +96,7 @@
   background-color: #111827;
   border-color: rgba(248, 250, 252, 0.7);
   transform: translateY(-1px);
+  cursor: pointer;
 }
 
 .header__logout-btn:active {

--- a/src/pages/BoardPage/BoardPage.css
+++ b/src/pages/BoardPage/BoardPage.css
@@ -1,10 +1,18 @@
 .board {
   background: var(--bg);
   min-height: 100vh;
-  padding: 32px 20px 60px;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  padding: 32px 20px 20px;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Arial,
+    sans-serif;
   color: var(--text);
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 .board__title {
@@ -16,6 +24,8 @@
 }
 
 .board__columns {
+  padding: 20px 0px;
+  flex: 1;
   display: grid;
   grid-template-columns: repeat(4, minmax(220px, 1fr));
   gap: 20px;
@@ -27,7 +37,9 @@
   border-radius: var(--radius);
   padding: 12px 14px;
   min-height: 340px;
-  transition: background-color 0.15s ease, border-color 0.15s ease;
+  transition:
+    background-color 0.15s ease,
+    border-color 0.15s ease;
 }
 
 .column__title {
@@ -61,15 +73,16 @@
   margin-bottom: 10px;
   font-size: 14px;
   line-height: 1.3;
-  transition: border-color 0.2s ease,
-              box-shadow 0.2s ease,
-              background-color 0.2s ease,
-              transform 0.08s ease;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease,
+    transform 0.08s ease;
 }
 
 .task:hover {
   border-color: #cbd5e1;
-  background-color: rgba(15, 23, 42, 0.02); 
+  background-color: rgba(15, 23, 42, 0.02);
   box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08); /* lift card on hover */
   transform: translateY(-1px);
 }
@@ -106,7 +119,6 @@
   margin-bottom: 18px;
 }
 
-
 .board__title {
   margin: 0;
   font-size: 22px;
@@ -121,18 +133,24 @@
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 10px;       
-  padding: 8px 12px; 
+  border-radius: 10px;
+  padding: 8px 12px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease, transform 0.06s ease;
-  box-shadow: 0 1px 0 rgba(0,0,0,0.04);
+  transition:
+    background 0.15s ease,
+    transform 0.06s ease;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.04);
   margin-left: auto;
 }
 
 /* hover / active states */
-.logout-btn:hover { background: var(--accent-hover); }
-.logout-btn:active { transform: translateY(1px); }
+.logout-btn:hover {
+  background: var(--accent-hover);
+}
+.logout-btn:active {
+  transform: translateY(1px);
+}
 
 /* small-screen adjustments: move title to left and button to right if needed */
 @media (max-width: 520px) {
@@ -148,8 +166,6 @@
     border-radius: 8px;
   }
 }
-
-
 
 @media (max-width: 980px) {
   .board__columns {

--- a/src/pages/BoardPage/BoardPage.jsx
+++ b/src/pages/BoardPage/BoardPage.jsx
@@ -5,6 +5,7 @@ import { advanceTask } from "../../api/tasks";
 import { STATUSES, getStatusLabel, canTransition } from "../../utils/status";
 import { Header } from "../../components/layout/Header/Header";
 import { Column } from "../../components/Board/Column";
+import { Footer } from "../../components/layout/Footer";
 
 import "./BoardPage.css";
 
@@ -121,6 +122,7 @@ export default function BoardPage() {
           />
         ))}
       </div>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
Added environment label (ENV: development | production) using import.meta.env.MODE.
Added GitHub link on the right side of the footer.
Footer now displays © {year} Olejra • ENV: {mode}.
Layout remains simple and minimal, no API calls or user data yet.
Prepared structure for future footer extensions (API status, versions, user info).