### PR TITLE
feat(frontend): add simple layout wrapper with shared header

### DIFF
--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -1,0 +1,10 @@
+.app-layout {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg, #05060a);
+}
+
+.app-layout__main {
+  flex: 1;
+}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,0 +1,13 @@
+import { Header } from "./Header/Header";
+import { Footer } from "./Footer";
+import "../layout/Layout.css";
+
+export function Layout({ userName, onLogout, children }) {
+  return (
+    <div className="app-layout">
+      <Header userName={userName} onLogout={onLogout} />
+      <main className="app-layout__main">{children}</main>
+      <Footer></Footer>
+    </div>
+  );
+}

--- a/src/pages/BoardPage/BoardPage.css
+++ b/src/pages/BoardPage/BoardPage.css
@@ -1,6 +1,5 @@
 .board {
   background: var(--bg);
-  min-height: 100vh;
   padding: 32px 20px 20px;
   font-family:
     system-ui,

--- a/src/pages/BoardPage/BoardPage.jsx
+++ b/src/pages/BoardPage/BoardPage.jsx
@@ -3,9 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { api } from "../../api/axios";
 import { advanceTask } from "../../api/tasks";
 import { STATUSES, getStatusLabel, canTransition } from "../../utils/status";
-import { Header } from "../../components/layout/Header/Header";
+import { Layout } from "../../components/layout/Layout";
 import { Column } from "../../components/Board/Column";
-import { Footer } from "../../components/layout/Footer";
 
 import "./BoardPage.css";
 
@@ -107,22 +106,21 @@ export default function BoardPage() {
   }
 
   return (
-    <div className="board">
-      <Header userName={`Hello, ${user?.email}`} onLogout={handleLogout} />
-
-      <div className="board__columns">
-        {STATUSES.map((status) => (
-          <Column
-            key={status}
-            title={getStatusLabel(status)}
-            tasks={columns[status]} // pass tasks array for this status
-            loadingById={loading} // full loading map
-            onOpenDetails={(taskId) => navigate(`/tasks/${taskId}`)}
-            onAdvance={handleAdvance}
-          />
-        ))}
+    <Layout userName={user ? `Hello, ${user.email}` : ""} onLogout={handleLogout}>
+      <div className="board">
+        <div className="board__columns">
+          {STATUSES.map((status) => (
+            <Column
+              key={status}
+              title={getStatusLabel(status)}
+              tasks={columns[status]} // pass tasks array for this status
+              loadingById={loading} // full loading map
+              onOpenDetails={(taskId) => navigate(`/tasks/${taskId}`)}
+              onAdvance={handleAdvance}
+            />
+          ))}
+        </div>
       </div>
-      <Footer />
-    </div>
+    </Layout>
   );
 }


### PR DESCRIPTION
Added a simple Layout component that wraps pages with a shared header and a main content area. Updated BoardPage.jsx to use Layout instead of rendering the header directly, while keeping all user and logout logic inside the page for now. The layout only receives userName, onLogout and children, so it stays easy to understand and reuse. Basic layout styles were added to ensure the header and content stretch to full viewport height. This is a small structural step that prepares the app for reusing the same shell across other authenticated pages later.