### PR TITLE
refactor: migrate core layout styles to design tokens

### DIFF
--- a/src/components/layout/Footer.css
+++ b/src/components/layout/Footer.css
@@ -1,8 +1,8 @@
 .olejra-footer {
   width: 100%;
-  background: #050816;
-  color: #9ca3af;
-  border-top: 1px solid #111827;
+  background: var(--accent);
+  color: var(--text-subtle);
+  border-top: 1px solid var(--header-border);
   font-size: 12px;
   display: flex;
   justify-content: space-between;
@@ -27,7 +27,7 @@
 
 .olejra-footer__link {
   text-decoration: none;
-  color: inherit;
+  color: var(--header-fg, inherit);
   opacity: 0.85;
 }
 

--- a/src/components/layout/Header/Header.css
+++ b/src/components/layout/Header/Header.css
@@ -2,9 +2,9 @@
 
 /* Main header wrapper */
 .header {
-  background-color: #020617; /* dark navy background */
-  color: #e5e7eb; /* light text */
-  border-bottom: 1px solid rgba(15, 23, 42, 0.7);
+  background-color: var(--accent); /* dark header background */
+  color: var(--header-fg); /* light text on dark header */
+  border-bottom: 1px solid var(--header-border);
 }
 
 /* Inner content layout */
@@ -30,10 +30,10 @@
   align-items: center;
   justify-content: center;
   padding: 0.45rem 1.25rem;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.45);
-  background: radial-gradient(circle at 0% 0%, #1f2937, #020617);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.7);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border, rgba(148, 163, 184, 0.45));
+  background: radial-gradient(circle at 0% 0%, #1f2937, var(--accent-soft, #020617));
+  box-shadow: var(--shadow-strong, 0 12px 24px rgba(15, 23, 42, 0.7));
 }
 
 .header__logo-text {
@@ -68,18 +68,18 @@
   font-size: 0.75rem;
   opacity: 0.8;
   padding: 0.1rem 0.55rem;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background-color: rgba(15, 23, 42, 0.9);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border, rgba(148, 163, 184, 0.5));
+  background-color: var(--accent-soft, rgba(15, 23, 42, 0.9));
 }
 
 /* Logout button */
 .header__logout-btn {
   padding: 0.45rem 0.9rem;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  background-color: #020617;
-  color: #e5e7eb;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border, rgba(148, 163, 184, 0.5));
+  background-color: var(--accent-soft, #020617);
+  color: var(--header-fg, #e5e7eb);
   font-size: 0.75rem;
   font-weight: 500;
   letter-spacing: 0.08em;
@@ -92,15 +92,15 @@
 }
 
 .header__logout-btn:hover {
-  background-color: #111827;
-  border-color: rgba(248, 250, 252, 0.7);
+  background-color: var(--accent, #111827);
+  border-color: var(--border, rgba(248, 250, 252, 0.7));
   transform: translateY(-1px);
   cursor: pointer;
 }
 
 .header__logout-btn:active {
   transform: translateY(0);
-  background-color: #020617;
+  background-color: var(--accent-soft, #020617);
 }
 
 /* Responsive tweaks */

--- a/src/index.css
+++ b/src/index.css
@@ -1,32 +1,65 @@
-/* Global styles */
 :root {
-  --bg:       #f3f4f6;   /* slightly darker than white background */
-  --card:     #ffffff;   /* pure white card */
-  --card-hover: #f9fafb; /* subtle contrast on hover */
+  /* Core surfaces */
+  --bg: #f3f4f6; /* app canvas background */
+  --bg-soft: #f9fafb; /* softer panels, headers */
+  --card: #ffffff; /* main card background */
+  --card-elevated: #ffffff; /* elevated cards if we need stronger shadow */
 
-  --border:   #d1d5db;   /* visible but soft border */
-  --border-hover: #cbd5e1; /* darker border on hover */
+  /* Borders */
+  --border-subtle: rgba(15, 23, 42, 0.04); /* hairline borders */
+  --border: rgba(15, 23, 42, 0.08); /* standard card borders */
+  --input-bg: #ffffff;
+  --input-border: #e5e7eb;
+  --input-border-focus: #cbd5e1;
 
-  --text:     #111827;   /* deep graphite text color */
-  --text-light: #4b5563; /* for descriptions and secondary text */
+  /* Typography */
+  --text: #111827; /* default text */
+  --text-muted: #6b7280; /* secondary text */
+  --text-subtle: #9ca3af; /* labels, meta */
 
-  --muted:    #6b7280;   /* muted gray for labels or hints */
+  /* Primary action */
+  --accent: #242427; /* solid black primary */
+  --accent-hover: #111827; /* hover state for primary */
+  --accent-soft: #0f172a; /* optional soft dark background */
+  --ring: rgba(148, 163, 184, 0.45); /* focus outline */
 
-  --accent: #111111;        /* rich deep black */
-  --accent-hover: #616161;  /* smooth dark gray hover */
+  /* Status badges */
+  --status-backlog-bg: #f4f4f5;
+  --status-backlog-border: #e4e4e7;
+  --status-backlog-text: #71717a;
 
-  --error:    #dc2626;   /* clean red for error messages */
+  --status-todo-bg: #eef2ff;
+  --status-todo-border: #e0e7ff;
+  --status-todo-text: #4f46e5;
+
+  --status-inprogress-bg: #fef3c7;
+  --status-inprogress-border: #facc15;
+  --status-inprogress-text: #92400e;
+
+  --status-done-bg: #dcfce7;
+  --status-done-border: #22c55e;
+  --status-done-text: #166534;
+
+  /* Radii */
+  --radius-card: 18px; /* big cards (board, details, login) */
+  --radius-input: 10px; /* inputs and buttons */
+  --radius-pill: 999px; /* pills and badges */
+
+  /* Shadows */
+  --shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.06);
+  --shadow-strong: 0 30px 80px rgba(15, 23, 42, 0.16);
 }
 
-html, body, #root {
-  height: 100%;
-}
-
+/* Global body styles using new tokens */
 body {
   margin: 0;
   background: var(--bg);
   color: var(--text);
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Apple Color Emoji","Segoe UI Emoji";
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    Arial,
+    sans-serif;
 }

--- a/src/pages/BoardPage/BoardPage.css
+++ b/src/pages/BoardPage/BoardPage.css
@@ -32,8 +32,8 @@
 
 .column {
   background: var(--card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
   padding: 12px 14px;
   min-height: 340px;
   transition:
@@ -47,18 +47,18 @@
   font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted);
+  color: var(--text-subtle);
 }
 
 /* When column has tasks */
 .column--active {
-  background-color: #fafbfc;
-  border-color: #d8dee9;
+  background-color: var(--bg-soft);
+  border-color: var(--border);
 }
 
 .column:hover {
-  background-color: #f5f7fb; /* slightly darker than board background so columns stand out */
-  border-color: #cbd5e1;
+  background-color: var(--bg-soft); /* slightly darker than board background so columns stand out */
+  border-color: var(--border);
 }
 
 .board__header {
@@ -82,7 +82,7 @@
   background: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 10px;
+  border-radius: var(--radius-input);
   padding: 8px 12px;
   font-weight: 600;
   cursor: pointer;
@@ -112,7 +112,7 @@
   }
   .logout-btn {
     padding: 6px 10px;
-    border-radius: 8px;
+    border-radius: var(--radius-input);
   }
 }
 
@@ -132,9 +132,9 @@
 .task {
   display: flex;
   align-items: stretch; /* діти тягнуться по висоті */
-  background: var(--card, #fff);
+  background: var(--card);
   border: 1px solid var(--border);
-  border-radius: 8px; /* можна 4px, якщо хочеш більш квадратну */
+  border-radius: var(--radius-input); /* можна 4px, якщо хочеш більш квадратну */
   overflow: hidden; /* щоб внутрішні елементи не вилазили за рамку */
   margin-bottom: 8px;
   padding: 0;

--- a/src/pages/LoginPage.css
+++ b/src/pages/LoginPage.css
@@ -5,7 +5,7 @@
   justify-content: center;
   padding: 32px 16px;
   box-sizing: border-box;
-  background: #f3f4f6;
+  background: var(--bg);
 }
 
 /* Main card */
@@ -13,13 +13,11 @@
   box-sizing: border-box;
   width: min(420px, 100%);
   padding: 32px 32px 26px;
-  background: #ffffff;
-  border-radius: 20px;
-  border: 1px solid rgba(15, 23, 42, 0.04);
-  box-shadow:
-    0 30px 80px rgba(15, 23, 42, 0.12),
-    0 0 0 1px rgba(15, 23, 42, 0.02);
-  color: #020617;
+  background: var(--card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-strong);
+  color: var(--text);
   font-family:
     system-ui,
     -apple-system,
@@ -35,8 +33,8 @@
   width: 40px;
   height: 40px;
   margin: 0 auto 20px;
-  border-radius: 999px;
-  background: #020617;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
   color: #ffffff;
   display: flex;
   align-items: center;
@@ -57,7 +55,7 @@
 .login-card__subtitle {
   margin: 0 0 26px;
   font-size: 14px;
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 /* Form fields */
@@ -73,7 +71,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.18em;
-  color: #9ca3af;
+  color: var(--text-subtle);
 }
 
 /* Inputs */
@@ -81,10 +79,10 @@
   width: 100%;
   box-sizing: border-box;
   padding: 10px 12px;
-  border-radius: 10px;
-  border: 1px solid #e5e7eb;
+  border-radius: var(--radius-input);
+  border: 1px solid var(--input-border);
+  background: var(--input-bg);
   font-size: 14px;
-  background: #ffffff;
   outline: none;
   transition:
     border-color 0.15s ease,
@@ -93,13 +91,13 @@
 }
 
 .login-card__input::placeholder {
-  color: #9ca3af;
+  color: var(--text-subtle);
 }
 
 .login-card__input:focus {
-  border-color: #cbd5e1;
+  border-color: var(--input-border-focus);
   box-shadow: 0 0 0 3px var(--ring, rgba(148, 163, 184, 0.4));
-  background: #ffffff;
+  background: var(--input-bg);
 }
 
 /* Submit button */
@@ -111,9 +109,9 @@
   width: 100%;
   margin-top: 8px;
   padding: 11px 14px;
-  border-radius: 10px;
-  border: 1px solid #020617;
-  background: #020617;
+  border-radius: var(--radius-input);
+  border: 1px solid var(--accent);
+  background: var(--accent);
   color: #ffffff;
   font-size: 14px;
   font-weight: 600;
@@ -127,7 +125,7 @@
 }
 
 .login-card__submit:hover:not(:disabled) {
-  background: #111827;
+  background: var(--accent-hover);
   box-shadow: 0 22px 55px rgba(15, 23, 42, 0.45);
 }
 
@@ -150,16 +148,16 @@
 .login-card__error {
   margin-top: 10px;
   font-size: 13px;
-  color: #ef4444;
+  color: var(--danger, #ef4444);
 }
 
 /* Footer text */
 .login-card__footer {
   margin-top: 24px;
   padding-top: 16px;
-  border-top: 1px solid #f3f4f6;
+  border-top: 1px solid var(--border-subtle);
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--text-subtle);
 }
 
 .login-card__footer-link {
@@ -167,7 +165,7 @@
   padding: 0;
   border: none;
   background: transparent;
-  color: #020617;
+  color: var(--accent);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -176,7 +174,7 @@
 }
 
 .login-card__footer-link:hover {
-  color: #111827;
+  color: var(--accent-hover);
 }
 
 /* Slightly tighter padding on very small screens */

--- a/src/pages/TaskDetailsPage.css
+++ b/src/pages/TaskDetailsPage.css
@@ -3,8 +3,8 @@
 /* Root container: light canvas under dark global header */
 .task-details {
   /* Use a light neutral background to match the board layout */
-  background: #f3f4f6;
-  color: #020617;
+  background: var(--bg);
+  color: var(--text);
   box-sizing: border-box;
 }
 
@@ -22,7 +22,7 @@
   padding: 0;
   border: none;
   background: transparent;
-  color: #9ca3af;
+  color: var(--text-subtle);
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.18em;
@@ -36,7 +36,7 @@
 }
 
 .task-details__back:hover {
-  color: #6b7280;
+  color: var(--text-muted);
   transform: translateX(-1px);
 }
 
@@ -63,14 +63,14 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.16em;
-  color: #9ca3af;
+  color: var(--text-subtle);
 }
 
 .task-details__title {
   font-size: 24px;
   font-weight: 600;
   letter-spacing: 0.02em;
-  color: #020617;
+  color: var(--text);
 }
 
 /* Edit button styled as a pill floating over light canvas */
@@ -79,14 +79,14 @@
   align-items: center;
   gap: 6px;
   padding: 8px 18px;
-  border-radius: 999px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: #ffffff;
-  color: #020617;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-subtle);
+  background: var(--card);
+  color: var(--text);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
-  box-shadow: 0 14px 35px rgba(15, 23, 42, 0.16);
+  box-shadow: var(--shadow-soft);
   transition:
     background 0.15s ease,
     transform 0.1s ease,
@@ -95,10 +95,10 @@
 }
 
 .task-details__edit-btn:hover {
-  background: #f9fafb;
-  border-color: rgba(15, 23, 42, 0.14);
+  background: var(--bg-soft);
+  border-color: var(--border);
   transform: translateY(-1px);
-  box-shadow: 0 18px 45px rgba(15, 23, 42, 0.22);
+  box-shadow: var(--shadow-strong);
 }
 
 .task-details__edit-icon {
@@ -125,16 +125,14 @@
 
 /* Meta card (left column) – light card with subtle shadow */
 .task-details__meta-card {
-  background: #ffffff;
-  border-radius: 18px;
-  border: none;
+  background: var(--card);
+  border-radius: var(--radius-card);
+  border: 1px solid var(--border-subtle);
   padding: 28px 30px;
   display: flex;
   flex-direction: column;
   gap: 18px;
-  box-shadow:
-    0 18px 50px rgba(15, 23, 42, 0.06),
-    0 0 0 1px rgba(148, 163, 184, 0.06);
+  box-shadow: var(--shadow-soft);
 }
 
 .task-details__meta-group {
@@ -148,12 +146,12 @@
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.14em;
-  color: #9ca3af;
+  color: var(--text-subtle);
 }
 
 .task-details__meta-value {
   font-size: 13px;
-  color: #4b5563;
+  color: var(--text-muted);
 }
 
 .task-details__meta-value--mono {
@@ -170,19 +168,19 @@
 .task-details__status-dot {
   width: 8px;
   height: 8px;
-  border-radius: 999px;
-  background: #f59e0b;
+  border-radius: var(--radius-pill);
+  background: var(--status-inprogress-border, #f59e0b);
   box-shadow: 0 0 10px rgba(245, 158, 11, 0.45);
 }
 
 .task-details__status-position {
   font-size: 12px;
-  color: #9ca3af;
+  color: var(--text-subtle);
 }
 
 /* Form card (right column) – large dark panel with inner card centered */
 .task-details__form-card {
-  border-radius: 18px;
+  border-radius: var(--radius-card);
   padding: 40px 46px;
   background: radial-gradient(circle at top, rgba(31, 41, 55, 0.75), rgba(15, 23, 42, 1));
   box-shadow:
@@ -226,10 +224,10 @@
 .task-details__input,
 .task-details__textarea,
 .task-details__select {
-  border-radius: 8px;
-  border: 1px solid rgba(55, 65, 81, 0.85);
-  background: #020617;
-  color: #e5e7eb;
+  border-radius: var(--radius-input);
+  border: 1px solid var(--input-border, rgba(55, 65, 81, 0.85));
+  background: var(--input-bg, #020617);
+  color: var(--text, #e5e7eb);
   font-size: 14px;
   padding: 10px 12px;
   outline: none;
@@ -254,18 +252,16 @@
 /* Placeholder color */
 .task-details__input::placeholder,
 .task-details__textarea::placeholder {
-  color: rgba(100, 116, 139, 0.9);
+  color: var(--text-subtle);
 }
 
 /* Focus state */
 .task-details__input:focus,
 .task-details__textarea:focus,
 .task-details__select:focus {
-  border-color: rgba(248, 250, 252, 0.95);
-  box-shadow:
-    0 0 0 1px rgba(248, 250, 252, 0.9),
-    0 0 14px rgba(248, 250, 252, 0.25);
-  background: #020617;
+  border-color: var(--input-border-focus, #cbd5e1);
+  box-shadow: 0 0 0 3px var(--ring);
+  background: var(--input-bg, #020617);
 }
 
 /* Disabled state used for read-only view */
@@ -274,8 +270,8 @@
 .task-details__select:disabled {
   cursor: default;
   opacity: 0.9;
-  background: #020617;
-  border-color: rgba(55, 65, 81, 0.9);
+  background: var(--input-bg, #020617);
+  border-color: var(--input-border, rgba(55, 65, 81, 0.9));
   box-shadow: none;
 }
 
@@ -291,10 +287,10 @@
 .task-details__primary-btn {
   min-width: 130px;
   padding: 9px 18px;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   border: none;
-  background: #f9fafb;
-  color: #020617;
+  background: var(--card);
+  color: var(--text);
   font-size: 13px;
   font-weight: 600;
   cursor: pointer;
@@ -307,7 +303,7 @@
 }
 
 .task-details__primary-btn:hover:not(:disabled) {
-  background: #ffffff;
+  background: var(--card);
   transform: translateY(-1px);
   box-shadow: 0 0 22px rgba(255, 255, 255, 0.22);
 }
@@ -322,10 +318,10 @@
 /* Secondary button (cancel) */
 .task-details__secondary-btn {
   padding: 9px 16px;
-  border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.7);
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border, rgba(148, 163, 184, 0.7));
   background: transparent;
-  color: rgba(148, 163, 184, 0.98);
+  color: var(--text-subtle);
   font-size: 13px;
   font-weight: 500;
   cursor: pointer;
@@ -338,9 +334,9 @@
 }
 
 .task-details__secondary-btn:hover:not(:disabled) {
-  background: rgba(15, 23, 42, 0.9);
-  border-color: rgba(226, 232, 240, 0.9);
-  color: #e5e7eb;
+  background: var(--accent-soft, rgba(15, 23, 42, 0.9));
+  border-color: var(--border);
+  color: var(--text, #e5e7eb);
   transform: translateY(-1px);
 }
 
@@ -357,7 +353,7 @@
   border-radius: 8px;
   border: 1px solid rgba(248, 113, 113, 0.6);
   background: rgba(127, 29, 29, 0.16);
-  color: #fecaca;
+  color: var(--danger, #fecaca);
   font-size: 12px;
 }
 


### PR DESCRIPTION
Refactored core layout styles to use the new Olejra design tokens.
Replaced all hard-coded colors, radii, borders and shadows across Header, Footer, Login, Task Details and Board.
Removed remaining blue tones and aligned everything to the new black theme (`--accent-soft`, `--header-fg`, `--text-subtle`, `--border-subtle`).
Unified input, button and card styling so all components share the same token-based system.
Eliminated fallback color values (`var(--x, #fff)`) to ensure consistent theming.
Checked all pages to confirm visual consistency with the updated Olejra design.