### PR TITLE
feat: refresh logo and login page UI

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -63,3 +63,46 @@ body {
     Arial,
     sans-serif;
 }
+
+.olejra-brand-link {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+/* Обгортка для вирівнювання */
+.olejra-logo-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Текст логотипу + Крапка */
+.olejra-logo-text {
+  font-family: "Inter", system-ui, sans-serif;
+  font-weight: 800; /* Жирний шрифт для брендингу */
+  font-size: 20px; /* Розмір */
+  letter-spacing: -0.02em; /* Трохи щільніший трекінг */
+  color: var(--text); /* Основний колір тексту (Чорний/Zinc-900) */
+  position: relative; /* База для позиціювання крапки */
+  padding-left: 14px; /* Відступ зліва для крапки */
+  line-height: 1;
+}
+
+/* Фіолетова крапка */
+.olejra-logo-text::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%); /* Центрування по вертикалі */
+
+  width: 8px; /* Діаметр */
+  height: 8px;
+  border-radius: 50%; /* Коло */
+
+  /* Колір крапки: змінна з теми або фіолетовий */
+  background-color: var(--brand-color, #a353f0);
+}

--- a/src/pages/LoginPage.css
+++ b/src/pages/LoginPage.css
@@ -1,3 +1,63 @@
+:root {
+  /* Core surfaces */
+  --bg: #f3f4f6;
+  --bg-soft: #f9fafb;
+  --card: #ffffff;
+  --card-elevated: #ffffff;
+
+  /* Borders */
+  --border-subtle: rgba(15, 23, 42, 0.04);
+  --border: rgba(15, 23, 42, 0.08);
+
+  /* Inputs */
+  --input-bg: #ffffff;
+  --input-border: #e5e7eb;
+
+  /* --- ЗМІНЕНО НА ФІОЛЕТОВИЙ (Olejra Accent) --- */
+  --input-border-focus: #a353f0;
+  --ring: rgba(163, 83, 240, 0.25);
+  /* ------------------------------------------- */
+
+  /* Typography */
+  --text: #111827;
+  --text-muted: #6b7280;
+  --text-subtle: #9ca3af;
+
+  /* Primary action */
+  --accent: #242427;
+  --accent-hover: #111827;
+  --accent-soft: #0f172a;
+
+  /* Status badges */
+  --status-backlog-bg: #f4f4f5;
+  --status-backlog-border: #e4e4e7;
+  --status-backlog-text: #71717a;
+
+  --status-todo-bg: #eef2ff;
+  --status-todo-border: #e0e7ff;
+  --status-todo-text: #4f46e5;
+
+  --status-inprogress-bg: #fef3c7;
+  --status-inprogress-border: #facc15;
+  --status-inprogress-text: #92400e;
+
+  --status-done-bg: #dcfce7;
+  --status-done-border: #22c55e;
+  --status-done-text: #166534;
+
+  /* Radii */
+  --radius-card: 18px;
+  --radius-input: 10px;
+  --radius-pill: 999px;
+
+  /* Shadows */
+  --shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.06);
+  --shadow-strong: 0 30px 80px rgba(15, 23, 42, 0.16);
+
+  /* Brand Color */
+  --brand-color: #a353f0;
+}
+
 .login-page {
   min-height: 100vh;
   display: flex;
@@ -26,22 +86,6 @@
     Arial,
     sans-serif;
   text-align: center;
-}
-
-/* Logo pill at the top */
-.login-card__logo {
-  width: 40px;
-  height: 40px;
-  margin: 0 auto 20px;
-  border-radius: var(--radius-pill);
-  background: var(--accent);
-  color: #ffffff;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  font-size: 18px;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.4);
 }
 
 /* Title and subtitle */
@@ -94,9 +138,10 @@
   color: var(--text-subtle);
 }
 
+/* Фіолетовий фокус тут підтягується зі змінних :root */
 .login-card__input:focus {
   border-color: var(--input-border-focus);
-  box-shadow: 0 0 0 3px var(--ring, rgba(148, 163, 184, 0.4));
+  box-shadow: 0 0 0 3px var(--ring);
   background: var(--input-bg);
 }
 
@@ -140,10 +185,6 @@
   box-shadow: none;
 }
 
-.login-card__submit-icon {
-  font-size: 15px;
-}
-
 /* Error message */
 .login-card__error {
   margin-top: 10px;
@@ -177,7 +218,6 @@
   color: var(--accent-hover);
 }
 
-/* Slightly tighter padding on very small screens */
 @media (max-width: 420px) {
   .login-card {
     padding: 26px 20px 22px;
@@ -186,4 +226,43 @@
   .login-card__title {
     font-size: 20px;
   }
+}
+
+/* Logo styles from Logo.css included for completeness if needed in same file */
+.olejra-brand-link {
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.olejra-logo-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.olejra-logo-text {
+  font-family: "Inter", system-ui, sans-serif;
+  font-weight: 800;
+  font-size: 20px;
+  letter-spacing: -0.02em;
+  color: var(--text);
+  position: relative;
+  padding-left: 14px;
+  line-height: 1;
+  margin-bottom: 24px;
+}
+
+.olejra-logo-text::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--brand-color);
 }

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -46,12 +46,14 @@ export default function LoginPage() {
     <div className="login-page">
       <form className="login-card" onSubmit={handleSubmit} noValidate>
         {/* Logo pill */}
-        <div className="login-card__logo" aria-hidden="true">
-          O
-        </div>
+        <a href="/" className="olejra-brand-link" aria-label="Go to dashboard">
+          <span className="olejra-logo-wrapper">
+            <span className="olejra-logo-text">OLEJRA</span>
+          </span>
+        </a>
 
         <h1 className="login-card__title">Welcome back</h1>
-        <p className="login-card__subtitle">Enter your email to sign in to Olejra</p>
+        <p className="login-card__subtitle">Enter your credentials to access the workspace</p>
 
         <div className="login-card__field">
           <label htmlFor="email" className="login-card__field-label">
@@ -63,7 +65,7 @@ export default function LoginPage() {
             className="login-card__input"
             inputMode="email"
             autoComplete="email"
-            placeholder="name@company.com"
+            placeholder="name@olejra.app"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             required


### PR DESCRIPTION
Updated the login page to use the new Olejra wordmark with the accent dot instead of the old logo pill.
Aligned the login card styles with our current monochrome design tokens (backgrounds, borders, text colors).
Kept the form structure and validation logic the same, only improved the visual hierarchy and spacing.
Cleaned up unused CSS for the old logo pill and submit icon to keep the stylesheet focused on the new design.
Manually checked login flow with valid and invalid credentials, error message rendering, and layout on small screens.